### PR TITLE
Add findAll functionality

### DIFF
--- a/src/main/scala/ca/valencik/ltls/http/HttpErrorHandler.scala
+++ b/src/main/scala/ca/valencik/ltls/http/HttpErrorHandler.scala
@@ -3,13 +3,14 @@ package ca.valencik.ltls.http
 import cats.Monad
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
-import ca.valencik.ltls.model.{ApiError, UserNotFound}
+import ca.valencik.ltls.model.{ApiError, UserNotFound, NoUsersFound}
 
 class HttpErrorHandler[F[_]: Monad] extends Http4sDsl[F] {
 
   // Map your business errors to responses here
   val handle: ApiError => F[Response[F]] = {
     case UserNotFound(u) => NotFound(s"User not found ${u.value}")
+    case NoUsersFound    => NotFound(s"Oops, no users found")
   }
 
 }

--- a/src/main/scala/ca/valencik/ltls/model.scala
+++ b/src/main/scala/ca/valencik/ltls/model.scala
@@ -10,6 +10,7 @@ object model {
   // Business errors
   sealed trait ApiError                       extends Product with Serializable
   case class UserNotFound(username: UserName) extends ApiError
+  case object NoUsersFound                    extends ApiError
 
   // Http model
   case class CreateUser(username: String, email: String)

--- a/src/main/scala/ca/valencik/ltls/repository/PostgresUserRepository.scala
+++ b/src/main/scala/ca/valencik/ltls/repository/PostgresUserRepository.scala
@@ -32,14 +32,9 @@ class PostgresUserRepository[F[_]: Async](xa: Transactor[F])
   override def findAll(): F[Option[List[User]]] = {
     val statement: ConnectionIO[List[UserDTO]] = UserStatement.findAll.to[List]
 
-    // You might have more than one query involving joins.
-    // In such case a for-comprehension would be better
     val program: ConnectionIO[List[User]] = statement.map(_.map(_.toUser))
 
-    program.map(Option.apply).transact(xa).recoverWith {
-      // In case the user is not unique in your db. Check out Doobie's docs.
-      case UnexpectedEnd => Async[F].delay(None)
-    }
+    program.map(Option.apply).transact(xa)
   }
 
 }

--- a/src/main/scala/ca/valencik/ltls/repository/PostgresUserRepository.scala
+++ b/src/main/scala/ca/valencik/ltls/repository/PostgresUserRepository.scala
@@ -29,12 +29,30 @@ class PostgresUserRepository[F[_]: Async](xa: Transactor[F])
     }
   }
 
+  override def findAll(): F[Option[List[User]]] = {
+    val statement: ConnectionIO[List[UserDTO]] = UserStatement.findAll.to[List]
+
+    // You might have more than one query involving joins.
+    // In such case a for-comprehension would be better
+    val program: ConnectionIO[List[User]] = statement.map(_.map(_.toUser))
+
+    program.map(Option.apply).transact(xa).recoverWith {
+      // In case the user is not unique in your db. Check out Doobie's docs.
+      case UnexpectedEnd => Async[F].delay(None)
+    }
+  }
+
 }
 
 object UserStatement {
 
   def findUser(username: UserName): Query0[UserDTO] = {
     sql"SELECT * FROM api_user WHERE username=${username.value}"
+      .query[UserDTO]
+  }
+
+  def findAll: Query0[UserDTO] = {
+    sql"SELECT * FROM api_user"
       .query[UserDTO]
   }
 

--- a/src/main/scala/ca/valencik/ltls/repository/algebra.scala
+++ b/src/main/scala/ca/valencik/ltls/repository/algebra.scala
@@ -6,6 +6,7 @@ object algebra {
 
   trait UserRepository[F[_]] {
     def findUser(username: UserName): F[Option[User]]
+    def findAll: F[Option[List[User]]]
   }
 
 }

--- a/src/main/scala/ca/valencik/ltls/service/UserService.scala
+++ b/src/main/scala/ca/valencik/ltls/service/UserService.scala
@@ -13,9 +13,12 @@ class UserService[F[_]: Async](userRepo: UserRepository[F]) {
       maybeUser.toRight[ApiError](UserNotFound(username))
     }
 
-  // TODO: To be completed by final user :)
   def findAll: F[ApiError Either List[User]] =
-    EitherT.rightT(List.empty[User]).value
+    userRepo.findAll map { maybeUsers =>
+      maybeUsers.toRight[ApiError](NoUsersFound)
+    }
+
+  // TODO: To be completed by final user :)
   def addUser(user: User): F[ApiError Either Unit]    = EitherT.rightT(()).value
   def updateUser(user: User): F[ApiError Either Unit] = EitherT.rightT(()).value
   def deleteUser(username: UserName): F[ApiError Either Unit] =

--- a/src/test/resources/db/migration/V2__Insert_User_Data.sql
+++ b/src/test/resources/db/migration/V2__Insert_User_Data.sql
@@ -1,2 +1,3 @@
 INSERT INTO api_user (username, email)
-VALUES ('gvolpe', 'gvolpe@github.com');
+VALUES ('gvolpe', 'gvolpe@github.com'),
+  ('valencik', 'valencik@github.com');

--- a/src/test/scala/ca/valencik/ltls/http/UserHttpEndpointSpec.scala
+++ b/src/test/scala/ca/valencik/ltls/http/UserHttpEndpointSpec.scala
@@ -33,6 +33,19 @@ class UserHttpEndpointSpec extends UserHttpEndpointFixture with FlatSpecLike wit
     }
   }
 
+  it should "find all users" in IOAssertion {
+    val allUsersString = users
+      .map{u => s"""{"username":"${u.username.value}","email":"${u.email.value}"}"""}
+      .mkString("[", ",", "]")
+    val request = Request[IO](uri = Uri(path = "/"))
+    httpService(request).value.flatMap { task =>
+      task.fold(IO(fail("Empty response")) *> IO.unit) { response =>
+        IO(response.status should be (Status.Ok)) *>
+        IO(response.body.asString shouldBe allUsersString)
+      }
+    }
+  }
+
   it should "Create a user" in IOAssertion {
     for {
       req   <- Request[IO](method = Method.POST).withBody(CreateUser("root", "root@unix.org"))

--- a/src/test/scala/ca/valencik/ltls/repository/UserRepositorySpec.scala
+++ b/src/test/scala/ca/valencik/ltls/repository/UserRepositorySpec.scala
@@ -32,8 +32,25 @@ class UserRepositorySpec extends RepositorySpec {
     }
   }
 
+  test("find all users"){
+    IOAssertion {
+      for {
+        allUsers <- repo.findAll
+      } yield {
+        allUsers.fold(fail("No users")) { us =>
+          assert(us.size == 2)
+          assert(us.contains(users.head))
+        }
+      }
+    }
+  }
+
   test("check find user query") {
     check(UserStatement.findUser(users.head.username))
+  }
+
+  test("check find all users query") {
+    check(UserStatement.findAll)
   }
 
 }

--- a/src/test/scala/ca/valencik/ltls/service/TestUserService.scala
+++ b/src/test/scala/ca/valencik/ltls/service/TestUserService.scala
@@ -2,17 +2,17 @@ package ca.valencik.ltls.service
 
 import cats.effect.IO
 import ca.valencik.ltls.TestUsers.users
-import ca.valencik.ltls.model.UserName
+import ca.valencik.ltls.model.{UserName, User}
 import ca.valencik.ltls.repository.algebra.UserRepository
 
 object TestUserService {
 
   class TestUserRepo extends UserRepository[IO] {
-    override def findUser(username: UserName) = IO {
+    override def findUser(username: UserName): IO[Option[User]] = IO {
       users.find(_.username.value == username.value)
     }
 
-    override def findAll = IO {
+    override def findAll: IO[Option[List[User]]] = IO {
       Some(users)
     }
 

--- a/src/test/scala/ca/valencik/ltls/service/TestUserService.scala
+++ b/src/test/scala/ca/valencik/ltls/service/TestUserService.scala
@@ -7,11 +7,17 @@ import ca.valencik.ltls.repository.algebra.UserRepository
 
 object TestUserService {
 
-  private val testUserRepo: UserRepository[IO] =
-    (username: UserName) => IO {
+  class TestUserRepo extends UserRepository[IO] {
+    override def findUser(username: UserName) = IO {
       users.find(_.username.value == username.value)
     }
 
-  val service: UserService[IO] = new UserService[IO](testUserRepo)
+    override def findAll = IO {
+      Some(users)
+    }
+
+  }
+
+  val service: UserService[IO] = new UserService[IO](new TestUserRepo)
 
 }

--- a/src/test/scala/ca/valencik/ltls/service/UserServiceSpec.scala
+++ b/src/test/scala/ca/valencik/ltls/service/UserServiceSpec.scala
@@ -20,4 +20,10 @@ class UserServiceSpec extends FlatSpecLike with Matchers {
     }.value
   }
 
+  it should "retrieve all users" in IOAssertion {
+    EitherT(TestUserService.service.findAll).map { allUsers =>
+      allUsers shouldBe users
+    }.value
+  }
+
 }


### PR DESCRIPTION
This PR is my first effort extending the project with another route.
Additions by file are detailed below alphabetically.
I've noticed the hierarchy of flow looks a bit like this:

```
UserService ->  UserRepository -> PostgresUserRespository
            \
             -> HttpErrorHandler -> Model
```
                          

## Main

__http/HttpErrorHandler__
- map the new `NoUsersFound` business/API error into a `Response` type

__model__
- add a new `NoUsersFound` API error

__repository/PostgresUserRepository__
- add new `findAll` method to `UserStatement` that contains the new sql
- add new `findAll` method to the Postgres implementation of `UserRepository` that builds and runs a Doobie program converting the results into `Option[List[User]]`

__repository/algebra__
- add `findAll` to the `UserRepository` trait

__service/UserService__
- implement `findAll` using the `UserRepository` and map the result to a `Either` of our desired `List[User]` or a `ApiError`

## Tests

__db/migration__
- add a new user to the db migrations that are used by Flycheck during testing

__http/UserHttpEndpointSpec__
- test that hitting route `/` will return a JSON string of all users

__repository/UserRepositorySpec__
- test that `findAll` on `PostgresUserRepository` returns 2 users and that one of them is as we expected
- test the the `findAll` query on `UserStatement` passes Doobie's typechecking `check`

__service/TestUserService__
- create a new class `TestUserRepo` that provides a `UserService` with `findUser` and `findAll`

__service/UserServiceSpec__
- test the `findAll` on `UserService` returns all users